### PR TITLE
Handle `undefined`/`null` `bufferRange` in `getBufferRange`

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -445,10 +445,12 @@ class StreamController extends EventHandler {
 
   getBufferRange(position) {
     var i, range;
-    for (i = this.bufferRange.length - 1; i >=0; i--) {
-      range = this.bufferRange[i];
-      if (position >= range.start && position <= range.end) {
-        return range;
+    if (this.bufferRange) {
+      for (i = this.bufferRange.length - 1; i >=0; i--) {
+        range = this.bufferRange[i];
+        if (position >= range.start && position <= range.end) {
+          return range;
+        }
       }
     }
     return null;


### PR DESCRIPTION
Prevent `undefined.length` `TypeError` by ensuring that `bufferRange` is actually defined.

This can occur when accessing `currentLevel` too early.

This is an alternative patch to dailymotion/hls.js#290.
